### PR TITLE
style: update settings button

### DIFF
--- a/src/components/Dashboard/DashboardHeader.jsx
+++ b/src/components/Dashboard/DashboardHeader.jsx
@@ -9,7 +9,8 @@ import {
   BugIcon,
   QuestionIcon,
   HeartIcon,
-  RepoIcon
+  RepoIcon,
+  GearIcon
 } from '@primer/octicons-react'
 import { Button, IconButton, Select, Checkbox, Label, ActionMenu, ActionList } from '@primer/react'
 import { ThemeToggle } from '../UI/ThemeToggle'


### PR DESCRIPTION
This PR updates the settings button to `Configure Repositories` and moves it inline with the filters row of the dashboard:

<img width="778" height="159" alt="image" src="https://github.com/user-attachments/assets/28376cf8-2500-4941-8ec3-0cb876e42ffe" />

This relates to Issue #24 to make it clearer to the user as to how to configure the repositories on the dashboard.